### PR TITLE
Refactor/Updated GPT endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@product-hackers/arcads",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "ArcAds is a DFP wrapper created by Arc Publishing with publishers in mind.",
   "main": "dist/arcads.js",
   "scripts": {

--- a/src/services/gpt.js
+++ b/src/services/gpt.js
@@ -8,7 +8,7 @@ export function initializeGPT() {
   window.googletag = window.googletag || {};
   window.googletag.cmd = window.googletag.cmd || [];
 
-  appendResource('script', '//www.googletagservices.com/tag/js/gpt.js', true, true);
+  appendResource('script', '//securepubads.g.doubleclick.net/tag/js/gpt.js', true, true);
 }
 
 /**


### PR DESCRIPTION
## On this branch

Ads publisher for lighthouse is reporting a change in the [recommended GPT](https://developers.google.com/publisher-ads-audits/reference/audits/loads-gpt-from-sgdn) endpoint. So, instead of:
`www.googletagservices.com/tag/js/gpt.js`
the library will use 
`securepubads.g.doubleclick.net/tag/js/gpt.js`

#### Verify

- [ ] Confirm that cross browser testing has been completed.

- [ ] Verify that no errors are present in the GPT console `window.googletag.openConsole()`.
 

#### Comments
_Include any comments to help with an effective code review here_
